### PR TITLE
Add quick fix for runtime error in no-deprecated.js

### DIFF
--- a/lib/rules/no-deprecated.js
+++ b/lib/rules/no-deprecated.js
@@ -101,6 +101,7 @@ module.exports = {
       return (
         deprecated &&
         deprecated[method] &&
+        deprecated[method][0] &&
         versionUtil.testReactVersion(context, deprecated[method][0])
       );
     }


### PR DESCRIPTION
Quick fix to avoid runtime error. Not sure though why the error is happening in first place.